### PR TITLE
Fix external link to Specter

### DIFF
--- a/warden/templates/warden/warden_layout.html
+++ b/warden/templates/warden/warden_layout.html
@@ -59,7 +59,7 @@
                 {%endif%}
 
                 {%if services['specter']['running']%}
-                <a href="{{services['specter']['connection'][0]}}:{{services['specter']['connection'][1]}}""
+                <a href="http://{{services['specter']['connection'][0]}}:{{services['specter']['connection'][1]}}""
                     target='_blank'>
                 <span class=" statusbox text-white">
                     Connected to Specter Wallet


### PR DESCRIPTION
Hi, really cool project :)

Was just playing around with it and saw that when I click on the Connected to Specter wallet, the link to Specter is broken since it tries to go within the app (i.e. to `http://127.0.0.1:25442/127.0.0.1:25441`) instead of going outside of the app context. Just added `http://` to fix that. 